### PR TITLE
docs, feign clients, tests, migration

### DIFF
--- a/.jhipster/Conversation.json
+++ b/.jhipster/Conversation.json
@@ -1,0 +1,38 @@
+{
+  "relationships": [
+    {
+      "relationshipId": 1,
+      "relationshipName": "message",
+      "otherEntityName": "message",
+      "relationshipType": "one-to-many",
+      "otherEntityRelationshipName": "conversation"
+    },
+    {
+      "relationshipId": 2,
+      "relationshipName": "user",
+      "otherEntityName": "userHolder",
+      "relationshipType": "many-to-many",
+      "ownerSide": false,
+      "otherEntityRelationshipName": "conversation"
+    }
+  ],
+  "fields": [
+    {
+      "fieldId": 1,
+      "fieldName": "active",
+      "fieldType": "Boolean",
+      "fieldValidateRules": [
+        "required"
+      ]
+    },
+    {
+      "fieldId": 2,
+      "fieldName": "title",
+      "fieldType": "String"
+    }
+  ],
+  "changelogDate": "20160610141608",
+  "dto": "no",
+  "pagination": "no",
+  "service": "no"
+}

--- a/.jhipster/Message.json
+++ b/.jhipster/Message.json
@@ -2,10 +2,10 @@
   "relationships": [
     {
       "relationshipId": 1,
-      "relationshipName": "user",
+      "relationshipName": "message",
       "otherEntityName": "userHolder",
-      "relationshipType": "one-to-many",
-      "otherEntityRelationshipName": "message"
+      "relationshipType": "many-to-one",
+        "otherEntityField": "id"
     },
     {
       "relationshipId": 2,

--- a/.jhipster/Message.json
+++ b/.jhipster/Message.json
@@ -1,14 +1,32 @@
 {
-  "relationships": [],
+  "relationships": [
+    {
+      "relationshipId": 1,
+      "relationshipName": "user",
+      "otherEntityName": "userHolder",
+      "relationshipType": "one-to-many",
+      "otherEntityRelationshipName": "message"
+    },
+    {
+      "relationshipId": 2,
+      "relationshipName": "conversation",
+      "otherEntityName": "conversation",
+      "relationshipType": "many-to-one",
+      "otherEntityField": "id"
+    }
+  ],
   "fields": [
     {
       "fieldId": 1,
-      "fieldName": "content",
-      "fieldType": "String"
+      "fieldName": "messageText",
+      "fieldType": "String",
+      "fieldValidateRules": [
+        "required"
+      ]
     }
   ],
   "changelogDate": "20160530071216",
   "dto": "no",
   "pagination": "no",
-  "service": "serviceClass"
+  "service": "no"
 }

--- a/.jhipster/UserHolder.json
+++ b/.jhipster/UserHolder.json
@@ -4,8 +4,8 @@
       "relationshipId": 1,
       "relationshipName": "message",
       "otherEntityName": "message",
-      "relationshipType": "many-to-one",
-      "otherEntityField": "id"
+      "relationshipType": "one-to-many",
+      "otherEntityRelationshipName": "message"
     },
     {
       "relationshipId": 2,

--- a/.jhipster/UserHolder.json
+++ b/.jhipster/UserHolder.json
@@ -1,0 +1,33 @@
+{
+  "relationships": [
+    {
+      "relationshipId": 1,
+      "relationshipName": "message",
+      "otherEntityName": "message",
+      "relationshipType": "many-to-one",
+      "otherEntityField": "id"
+    },
+    {
+      "relationshipId": 2,
+      "relationshipName": "conversation",
+      "otherEntityName": "conversation",
+      "relationshipType": "many-to-many",
+      "otherEntityField": "id",
+      "ownerSide": true
+    }
+  ],
+  "fields": [
+    {
+      "fieldId": 1,
+      "fieldName": "userId",
+      "fieldType": "Long",
+      "fieldValidateRules": [
+        "required"
+      ]
+    }
+  ],
+  "changelogDate": "20160610141609",
+  "dto": "no",
+  "pagination": "no",
+  "service": "no"
+}

--- a/Message.jh
+++ b/Message.jh
@@ -1,0 +1,34 @@
+/*
+* id, "created at" und "updated at" sind bereits Spalten jeder entität
+* es ist ein einfacher Textchat, daher gibt es nur eine Textnachricht
+*/
+entity Message {
+	messageText String required
+}
+
+/*
+* Eine Konversation kann aktiv sein, und sammelt Benutzer und Nachrichten
+*/
+entity Conversation {
+	active Boolean required,
+    title String //brauchen wir das?
+}
+
+/*
+* Stellvertretung des Users
+*
+entity UserHolder {
+	userId Long required
+}
+
+relationship ManyToMany {
+	UserHolder{conversation} to Conversation{user}
+}
+
+relationship OneToMany {
+	Conversation{message} to Message{conversation}
+}
+
+relationship OneToMany {
+	Message{user} to UserHolder
+}

--- a/app.jh
+++ b/app.jh
@@ -1,9 +1,25 @@
+
 entity Message {
-
-    content String,
-
-
-
+	messageText String required
 }
 
-service Message with serviceClass
+entity Conversation {
+	active Boolean required,
+    title String //brauchen wir das?
+}
+
+entity UserHolder {
+	userId Long required
+}
+
+relationship ManyToMany {
+	UserHolder{conversation} to Conversation{user}
+}
+
+relationship OneToMany {
+	Conversation{message} to Message{conversation}
+}
+
+relationship OneToMany {
+	Message{user} to UserHolder
+}

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ test {
     include '**/*UnitTest*'
     include '**/*IntTest*'
 
-    ignoreFailures true
+    ignoreFailures false
     reports.html.enabled = false
 }
 
@@ -127,7 +127,7 @@ dependencies {
     compile ("com.ryantenney.metrics:metrics-spring:${metrics_spring_version}") {
         exclude(module: 'metrics-core')
         exclude(module: 'metrics-healthchecks')
-    } 
+    }
     compile("com.zaxxer:HikariCP:${HikariCP_version}") {
         exclude(module: 'tools')
     }
@@ -137,7 +137,7 @@ dependencies {
     compile "javax.transaction:javax.transaction-api"
     compile "org.apache.geronimo.javamail:geronimo-javamail_1.4_mail:${geronimo_javamail_1_4_mail_version}"
     compile "org.hibernate:hibernate-core:${hibernate_entitymanager_version}"
-    
+
     compile "org.hibernate:hibernate-envers"
     compile "org.hibernate:hibernate-validator"
     compile ("org.liquibase:liquibase-core:${liquibase_core_version}") {
@@ -177,7 +177,7 @@ dependencies {
     compile("io.springfox:springfox-swagger2:${springfox_version}"){
         exclude module: 'mapstruct'
     }
-    
+
     compile "org.postgresql:postgresql"
     compile "com.h2database:h2"
     compile "fr.ippon.spark.metrics:metrics-spark-reporter:${metrics_spark_reporter_version}"
@@ -190,8 +190,8 @@ dependencies {
     testCompile "org.mockito:mockito-core"
     testCompile "com.mattbertolini:liquibase-slf4j:${liquibase_slf4j_version}"
     testCompile "org.hamcrest:hamcrest-library"
-    
-    
+
+
     optional "org.springframework.boot:spring-boot-configuration-processor:${spring_boot_version}"
     //jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ buildscript {
         classpath "org.springframework.build.gradle:propdeps-plugin:0.0.7"
         classpath "se.transmode.gradle:gradle-docker:1.2"
         classpath "io.spring.gradle:dependency-management-plugin:0.5.6.RELEASE"
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11'
+        classpath 'io.github.robwin:swagger2markup-gradle-plugin:0.9.2'
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
@@ -73,6 +76,7 @@ apply from: 'gradle/liquibase.gradle'
 
 apply from: 'gradle/mapstruct.gradle'
 apply from: 'gradle/docker.gradle'
+apply from: 'gradle/swagger2markup.gradle'
 //jhipster-needle-gradle-apply-from - JHipster will add additional gradle scripts to be applied here
 
 if (project.hasProperty('prod')) {
@@ -193,6 +197,7 @@ dependencies {
 
 
     optional "org.springframework.boot:spring-boot-configuration-processor:${spring_boot_version}"
+    testCompile 'io.springfox:springfox-staticdocs:2.4.0'
     //jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,7 @@ dependencies {
     testCompile "com.jayway.awaitility:awaitility:${awaility_version}"
     testCompile "com.jayway.jsonpath:json-path"
     testCompile "org.springframework.boot:spring-boot-starter-test"
+    testCompile "org.springframework.security:spring-security-test"
     testCompile "org.assertj:assertj-core:${assertj_core_version}"
     testCompile "junit:junit"
     testCompile "org.mockito:mockito-core"

--- a/gradle/swagger2markup.gradle
+++ b/gradle/swagger2markup.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'io.github.robwin.swagger2markup'
+
+ext {
+    asciiDocOutputDir = file("${buildDir}/asciidoc")
+    swaggerOutputDir = file("${buildDir}/swagger")
+}
+
+convertSwagger2markup {
+    dependsOn test
+    inputDir swaggerOutputDir
+    pathsGroupedBy 'TAGS'
+}
+
+asciidoctorj {
+    version = '1.5.4'
+}
+
+asciidoctor {
+    dependsOn convertSwagger2markup
+    sources {
+        include 'index.adoc'
+    }
+    backends = ['html5', 'pdf']
+    attributes = [
+        doctype: 'book',
+        toc: 'left',
+        toclevels: '3',
+        numbered: '',
+        sectlinks: '',
+        sectanchors: '',
+        hardbreaks: '',
+        generated: asciiDocOutputDir
+    ]
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Mon Apr 25 07:22:42 CEST 2016
+#Tue Jun 21 18:11:12 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,3 @@
+include::{generated}/overview.adoc[]
+include::{generated}/paths.adoc[]
+include::{generated}/definitions.adoc[]

--- a/src/main/java/de/extremeenvironment/messageservice/MessageServiceApp.java
+++ b/src/main/java/de/extremeenvironment/messageservice/MessageServiceApp.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 @EnableAutoConfiguration(exclude = { MetricFilterAutoConfiguration.class, MetricRepositoryAutoConfiguration.class })
 @EnableConfigurationProperties({ JHipsterProperties.class, LiquibaseProperties.class })
 @EnableEurekaClient
-@EnableFeignClients
 public class MessageServiceApp {
 
     private static final Logger log = LoggerFactory.getLogger(MessageServiceApp.class);

--- a/src/main/java/de/extremeenvironment/messageservice/client/Account.java
+++ b/src/main/java/de/extremeenvironment/messageservice/client/Account.java
@@ -1,0 +1,90 @@
+package de.extremeenvironment.messageservice.client;
+
+import java.util.Set;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+public class Account {
+    private String login;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String email;
+
+    private boolean activated = false;
+
+    private String langKey;
+
+    private long id;
+
+    private Set<String> authorities;
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isActivated() {
+        return activated;
+    }
+
+    public void setActivated(boolean activated) {
+        this.activated = activated;
+    }
+
+    public String getLangKey() {
+        return langKey;
+    }
+
+    public void setLangKey(String langKey) {
+        this.langKey = langKey;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Set<String> getAuthorities() {
+        return authorities;
+    }
+
+    public void setAuthorities(Set<String> authorities) {
+        this.authorities = authorities;
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/client/Account.java
+++ b/src/main/java/de/extremeenvironment/messageservice/client/Account.java
@@ -24,6 +24,19 @@ public class Account {
 
     private Set<String> authorities;
 
+    public Account() {
+    }
+
+    public Account(long id, String login, String firstName, String lastName, String email, boolean activated, String langKey) {
+        this.id = id;
+        this.login = login;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.activated = activated;
+        this.langKey = langKey;
+    }
+
     public String getLogin() {
         return login;
     }

--- a/src/main/java/de/extremeenvironment/messageservice/client/User.java
+++ b/src/main/java/de/extremeenvironment/messageservice/client/User.java
@@ -1,0 +1,9 @@
+package de.extremeenvironment.messageservice.client;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+public class User {
+}

--- a/src/main/java/de/extremeenvironment/messageservice/client/UserClient.java
+++ b/src/main/java/de/extremeenvironment/messageservice/client/UserClient.java
@@ -1,0 +1,22 @@
+package de.extremeenvironment.messageservice.client;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.List;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+@FeignClient("http://userservice/api")
+public interface UserClient {
+    @RequestMapping(method = RequestMethod.GET, value = "/users")
+    List<User> getUsers();
+
+    @RequestMapping(method = RequestMethod.GET, value = "/users/{userName}")
+    Account getAccount(@PathVariable("userName") String userName);
+}

--- a/src/main/java/de/extremeenvironment/messageservice/client/UserTestClient.java
+++ b/src/main/java/de/extremeenvironment/messageservice/client/UserTestClient.java
@@ -1,0 +1,38 @@
+package de.extremeenvironment.messageservice.client;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+@Component
+@Profile("test")
+@Primary
+public class UserTestClient implements UserClient {
+
+    @Override
+    public List<User> getUsers() {
+        return new LinkedList<>();
+    }
+
+    @Override
+    public Account getAccount(@PathVariable("userName") String userName) {
+        return new Account(
+            42,
+            userName,
+            userName,
+            userName,
+            userName + "@example.com",
+            true,
+            "de"
+        );
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/config/FeignConfiguration.java
+++ b/src/main/java/de/extremeenvironment/messageservice/config/FeignConfiguration.java
@@ -1,0 +1,16 @@
+package de.extremeenvironment.messageservice.config;
+
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+@Configuration
+@Profile("!test")
+@EnableFeignClients(basePackages = "de.extremeenvironment.messageservice.client")
+public class FeignConfiguration {
+}

--- a/src/main/java/de/extremeenvironment/messageservice/config/LoadBalancedResourceDetails.java
+++ b/src/main/java/de/extremeenvironment/messageservice/config/LoadBalancedResourceDetails.java
@@ -1,5 +1,7 @@
 package de.extremeenvironment.messageservice.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
@@ -11,6 +13,8 @@ import java.net.URISyntaxException;
 
 @Component
 public class LoadBalancedResourceDetails extends ClientCredentialsResourceDetails {
+    
+    Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     public LoadBalancedResourceDetails(JHipsterProperties jHipsterProperties) {
@@ -46,7 +50,7 @@ public class LoadBalancedResourceDetails extends ClientCredentialsResourceDetail
 
                 return newUrl;
             } catch (URISyntaxException e) {
-                e.printStackTrace();
+                log.error("{}: {}", e.getClass().toString(), e.getMessage());
 
                 return super.getAccessTokenUri();
             }

--- a/src/main/java/de/extremeenvironment/messageservice/config/LoadBalancedResourceDetails.java
+++ b/src/main/java/de/extremeenvironment/messageservice/config/LoadBalancedResourceDetails.java
@@ -12,8 +12,8 @@ import java.net.URISyntaxException;
 
 
 @Component
-public class LoadBalancedResourceDetails extends ClientCredentialsResourceDetails {
-    
+public class    LoadBalancedResourceDetails extends ClientCredentialsResourceDetails {
+
     Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired

--- a/src/main/java/de/extremeenvironment/messageservice/config/MicroserviceSecurityConfiguration.java
+++ b/src/main/java/de/extremeenvironment/messageservice/config/MicroserviceSecurityConfiguration.java
@@ -9,11 +9,14 @@ import feign.RequestInterceptor;
 import org.springframework.cloud.security.oauth2.client.feign.OAuth2FeignRequestInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
@@ -37,6 +40,7 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     @Inject
     LoadBalancedResourceDetails loadBalancedResourceDetails;
 
+
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http
@@ -56,6 +60,11 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
 
     }
 
+    @Override
+    public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
+        resources.stateless(false);
+    }
+
     @Bean
     public TokenStore tokenStore() {
         return new JwtTokenStore(jwtAccessTokenConverter());
@@ -73,5 +82,7 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     public RequestInterceptor getOAuth2RequestInterceptor() throws IOException {
         return new OAuth2FeignRequestInterceptor(new DefaultOAuth2ClientContext(), loadBalancedResourceDetails);
     }
+
+
 }
 

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
@@ -29,7 +29,7 @@ public class Conversation implements Serializable {
     @Column(name = "title")
     private String title;
 
-    @OneToMany(mappedBy = "conversation", orphanRemoval = true)
+    @OneToMany(mappedBy = "conversation", orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnore
     private Set<Message> messages = new HashSet<>();
 

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 
 /**
  * A Conversation.
- * test
  */
 @Entity
 @Table(name = "conversation")
@@ -29,7 +28,6 @@ public class Conversation implements Serializable {
 
     @Column(name = "title")
     private String title;
-
 
     @OneToMany(mappedBy = "conversation")
     @JsonIgnore

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
@@ -82,6 +82,11 @@ public class Conversation implements Serializable {
         messages.add(message);
     }
 
+    public void addMember(UserHolder userHolder) {
+        userHolder.getConversations().add(this);
+        users.add(userHolder);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
@@ -24,12 +24,12 @@ public class Conversation implements Serializable {
 
     @NotNull
     @Column(name = "active", nullable = false)
-    private Boolean active;
+    private Boolean active = true;
 
     @Column(name = "title")
     private String title;
 
-    @OneToMany(mappedBy = "conversation")
+    @OneToMany(mappedBy = "conversation", orphanRemoval = true)
     @JsonIgnore
     private Set<Message> messages = new HashSet<>();
 
@@ -75,6 +75,11 @@ public class Conversation implements Serializable {
 
     public void setUsers(Set<UserHolder> userHolders) {
         this.users = userHolders;
+    }
+
+    public void addMessage(Message message) {
+        message.setConversation(this);
+        messages.add(message);
     }
 
     @Override

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Conversation.java
@@ -1,0 +1,110 @@
+package de.extremeenvironment.messageservice.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+import javax.validation.constraints.*;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Objects;
+
+/**
+ * A Conversation.
+ * test
+ */
+@Entity
+@Table(name = "conversation")
+public class Conversation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @NotNull
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+
+    @Column(name = "title")
+    private String title;
+
+
+    @OneToMany(mappedBy = "conversation")
+    @JsonIgnore
+    private Set<Message> messages = new HashSet<>();
+
+    @ManyToMany(mappedBy = "conversations")
+    @JsonIgnore
+    private Set<UserHolder> users = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Boolean isActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Set<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(Set<Message> messages) {
+        this.messages = messages;
+    }
+
+    public Set<UserHolder> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<UserHolder> userHolders) {
+        this.users = userHolders;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Conversation conversation = (Conversation) o;
+        if(conversation.id == null || id == null) {
+            return false;
+        }
+        return Objects.equals(id, conversation.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Conversation{" +
+            "id=" + id +
+            ", active='" + active + "'" +
+            ", title='" + title + "'" +
+            '}';
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -24,7 +24,7 @@ public class Message implements Serializable {
     private String messageText;
 
     @ManyToOne
-    private UserHolder user = new UserHolder();
+    private UserHolder user;
 
     @ManyToOne
     private Conversation conversation;

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -1,12 +1,9 @@
 package de.extremeenvironment.messageservice.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import javax.validation.constraints.*;
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.Objects;
 
 /**
@@ -26,9 +23,8 @@ public class Message implements Serializable {
     @Column(name = "message_text", nullable = false)
     private String messageText;
 
-    @OneToMany(mappedBy = "message")
-    @JsonIgnore
-    private Set<UserHolder> users = new HashSet<>();
+    @ManyToOne
+    private UserHolder user;
 
     @ManyToOne
     private Conversation conversation;
@@ -49,12 +45,12 @@ public class Message implements Serializable {
         this.messageText = messageText;
     }
 
-    public Set<UserHolder> getUsers() {
-        return users;
+    public UserHolder getUser() {
+        return user;
     }
 
-    public void setUsers(Set<UserHolder> userHolders) {
-        this.users = userHolders;
+    public void setUser(UserHolder userHolder) {
+        this.user = userHolder;
     }
 
     public Conversation getConversation() {

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  */
 @Entity
 @Table(name = "message")
-public class Message implements Serializable {
+public class Message extends AbstractAuditingEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -1,8 +1,12 @@
 package de.extremeenvironment.messageservice.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
+import javax.validation.constraints.*;
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Objects;
 
 /**
@@ -18,8 +22,16 @@ public class Message implements Serializable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "content")
-    private String content;
+    @NotNull
+    @Column(name = "message_text", nullable = false)
+    private String messageText;
+
+    @OneToMany(mappedBy = "message")
+    @JsonIgnore
+    private Set<UserHolder> users = new HashSet<>();
+
+    @ManyToOne
+    private Conversation conversation;
 
     public Long getId() {
         return id;
@@ -29,12 +41,28 @@ public class Message implements Serializable {
         this.id = id;
     }
 
-    public String getContent() {
-        return content;
+    public String getMessageText() {
+        return messageText;
     }
 
-    public void setContent(String content) {
-        this.content = content;
+    public void setMessageText(String messageText) {
+        this.messageText = messageText;
+    }
+
+    public Set<UserHolder> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<UserHolder> userHolders) {
+        this.users = userHolders;
+    }
+
+    public Conversation getConversation() {
+        return conversation;
+    }
+
+    public void setConversation(Conversation conversation) {
+        this.conversation = conversation;
     }
 
     @Override
@@ -61,7 +89,7 @@ public class Message implements Serializable {
     public String toString() {
         return "Message{" +
             "id=" + id +
-            ", content='" + content + "'" +
+            ", messageText='" + messageText + "'" +
             '}';
     }
 }

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -24,7 +24,7 @@ public class Message implements Serializable {
     private String messageText;
 
     @ManyToOne
-    private UserHolder user;
+    private UserHolder user = new UserHolder();
 
     @ManyToOne
     private Conversation conversation;

--- a/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/Message.java
@@ -29,6 +29,13 @@ public class Message implements Serializable {
     @ManyToOne
     private Conversation conversation;
 
+    public Message() {
+    }
+
+    public Message(String messageText) {
+        this.messageText = messageText;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
@@ -1,5 +1,6 @@
 package de.extremeenvironment.messageservice.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import javax.validation.constraints.*;
@@ -10,7 +11,6 @@ import java.util.Objects;
 
 /**
  * A UserHolder.
- * test2
  */
 @Entity
 @Table(name = "user_holder")
@@ -26,8 +26,9 @@ public class UserHolder implements Serializable {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @ManyToOne
-    private Message message;
+    @OneToMany(mappedBy = "user")
+    @JsonIgnore
+    private Set<Message> messages = new HashSet<>();
 
     @ManyToMany
     @JoinTable(name = "user_holder_conversation",
@@ -51,12 +52,12 @@ public class UserHolder implements Serializable {
         this.userId = userId;
     }
 
-    public Message getMessage() {
-        return message;
+    public Set<Message> getMessages() {
+        return messages;
     }
 
-    public void setMessage(Message message) {
-        this.message = message;
+    public void setMessages(Set<Message> messages) {
+        this.messages = messages;
     }
 
     public Set<Conversation> getConversations() {

--- a/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
@@ -1,0 +1,97 @@
+package de.extremeenvironment.messageservice.domain;
+
+
+import javax.persistence.*;
+import javax.validation.constraints.*;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Objects;
+
+/**
+ * A UserHolder.
+ * test2
+ */
+@Entity
+@Table(name = "user_holder")
+public class UserHolder implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @NotNull
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne
+    private Message message;
+
+    @ManyToMany
+    @JoinTable(name = "user_holder_conversation",
+               joinColumns = @JoinColumn(name="user_holders_id", referencedColumnName="ID"),
+               inverseJoinColumns = @JoinColumn(name="conversations_id", referencedColumnName="ID"))
+    private Set<Conversation> conversations = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+
+    public Set<Conversation> getConversations() {
+        return conversations;
+    }
+
+    public void setConversations(Set<Conversation> conversations) {
+        this.conversations = conversations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserHolder userHolder = (UserHolder) o;
+        if(userHolder.id == null || id == null) {
+            return false;
+        }
+        return Objects.equals(id, userHolder.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+        return "UserHolder{" +
+            "id=" + id +
+            ", userId='" + userId + "'" +
+            '}';
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
@@ -26,10 +26,13 @@ public class UserHolder implements Serializable {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @NotNull
+    @Column(name = "username", nullable = false)
+    private String username;
+
     @OneToMany(mappedBy = "user")
     @JsonIgnore
     private Set<Message> messages = new HashSet<>();
-
     @ManyToMany
     @JoinTable(name = "user_holder_conversation",
                joinColumns = @JoinColumn(name="user_holders_id", referencedColumnName="ID"),
@@ -41,6 +44,11 @@ public class UserHolder implements Serializable {
 
     public UserHolder(Long userId) {
         this.userId = userId;
+    }
+
+    public UserHolder(Long userId, String username) {
+        this.userId = userId;
+        this.username = username;
     }
 
     public Long getId() {
@@ -101,5 +109,13 @@ public class UserHolder implements Serializable {
             "id=" + id +
             ", userId='" + userId + "'" +
             '}';
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
+++ b/src/main/java/de/extremeenvironment/messageservice/domain/UserHolder.java
@@ -36,6 +36,13 @@ public class UserHolder implements Serializable {
                inverseJoinColumns = @JoinColumn(name="conversations_id", referencedColumnName="ID"))
     private Set<Conversation> conversations = new HashSet<>();
 
+    public UserHolder() {
+    }
+
+    public UserHolder(Long userId) {
+        this.userId = userId;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/de/extremeenvironment/messageservice/repository/ConversationRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/ConversationRepository.java
@@ -1,0 +1,15 @@
+package de.extremeenvironment.messageservice.repository;
+
+import de.extremeenvironment.messageservice.domain.Conversation;
+
+import org.springframework.data.jpa.repository.*;
+
+import java.util.List;
+
+/**
+ * Spring Data JPA repository for the Conversation entity.
+ */
+@SuppressWarnings("unused")
+public interface ConversationRepository extends JpaRepository<Conversation,Long> {
+
+}

--- a/src/main/java/de/extremeenvironment/messageservice/repository/ConversationRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/ConversationRepository.java
@@ -3,13 +3,22 @@ package de.extremeenvironment.messageservice.repository;
 import de.extremeenvironment.messageservice.domain.Conversation;
 
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Spring Data JPA repository for the Conversation entity.
  */
 @SuppressWarnings("unused")
 public interface ConversationRepository extends JpaRepository<Conversation,Long> {
+    @Query(
+        "select conversation " +
+        "from Conversation conversation " +
+        "inner join conversation.users users " +
+        "where users.userId = :userId"
+    )
 
+    List<Conversation> readConversationsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/de/extremeenvironment/messageservice/repository/MessageRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/MessageRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
  */
 @SuppressWarnings("unused")
 public interface MessageRepository extends JpaRepository<Message,Long> {
-
+    List<Message> findAllByConversationId(Long messageId);
 }

--- a/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.security.access.method.P;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Spring Data JPA repository for the UserHolder entity.
@@ -27,4 +28,6 @@ public interface UserHolderRepository extends JpaRepository<UserHolder,Long> {
         "where conversations.id = :conversationId"
     )
     List<UserHolder> findAllByConversationId(@Param("conversationId") Long conversationId);
+
+    Optional<UserHolder> findOneByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
@@ -4,6 +4,7 @@ import de.extremeenvironment.messageservice.domain.UserHolder;
 
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.access.method.P;
 
 import java.util.List;
 
@@ -19,4 +20,11 @@ public interface UserHolderRepository extends JpaRepository<UserHolder,Long> {
     @Query("select userHolder from UserHolder userHolder left join fetch userHolder.conversations where userHolder.id =:id")
     UserHolder findOneWithEagerRelationships(@Param("id") Long id);
 
+    @Query(
+        "select userHolder " +
+        "from UserHolder userHolder " +
+        "left join userHolder.conversations conversations " +
+        "where conversations.id = :conversationId"
+    )
+    List<UserHolder> findAllByConversationId(@Param("conversationId") Long conversationId);
 }

--- a/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
+++ b/src/main/java/de/extremeenvironment/messageservice/repository/UserHolderRepository.java
@@ -1,0 +1,22 @@
+package de.extremeenvironment.messageservice.repository;
+
+import de.extremeenvironment.messageservice.domain.UserHolder;
+
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * Spring Data JPA repository for the UserHolder entity.
+ */
+@SuppressWarnings("unused")
+public interface UserHolderRepository extends JpaRepository<UserHolder,Long> {
+
+    @Query("select distinct userHolder from UserHolder userHolder left join fetch userHolder.conversations")
+    List<UserHolder> findAllWithEagerRelationships();
+
+    @Query("select userHolder from UserHolder userHolder left join fetch userHolder.conversations where userHolder.id =:id")
+    UserHolder findOneWithEagerRelationships(@Param("id") Long id);
+
+}

--- a/src/main/java/de/extremeenvironment/messageservice/service/ConversationService.java
+++ b/src/main/java/de/extremeenvironment/messageservice/service/ConversationService.java
@@ -1,0 +1,32 @@
+package de.extremeenvironment.messageservice.service;
+
+import de.extremeenvironment.messageservice.domain.Conversation;
+import de.extremeenvironment.messageservice.domain.Message;
+import de.extremeenvironment.messageservice.repository.ConversationRepository;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+
+/**
+ * Created by on 21.06.16.
+ *
+ * @author David Steiman
+ */
+@Service
+public class ConversationService {
+    private ConversationRepository conversationRepository;
+
+    @Inject
+    public void setConversationRepository(ConversationRepository conversationRepository) {
+        this.conversationRepository = conversationRepository;
+    }
+
+    public void addMessageToConversation(Conversation conversation, Message message) {
+        if (conversation == null || message == null) {
+            throw new IllegalArgumentException("neither conversation nor message should be null");
+        }
+
+        conversation.getMessages().add(message);
+        message.setConversation(conversation);
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/service/UserHolderService.java
+++ b/src/main/java/de/extremeenvironment/messageservice/service/UserHolderService.java
@@ -1,5 +1,6 @@
 package de.extremeenvironment.messageservice.service;
 
+import de.extremeenvironment.messageservice.client.Account;
 import de.extremeenvironment.messageservice.domain.UserHolder;
 import de.extremeenvironment.messageservice.repository.UserHolderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +20,9 @@ public class UserHolderService {
         this.userHolderRepository = userHolderRepository;
     }
 
-    public UserHolder findOrCreateByUserId(Long id) {
+    public UserHolder findOrCreateByAccount(Account source) {
         return userHolderRepository
-            .findOneByUserId(id)
-            .orElse(userHolderRepository.save(new UserHolder(id)));
+            .findOneByUserId(source.getId())
+            .orElse(userHolderRepository.save(new UserHolder(source.getId(), source.getLogin())));
     }
 }

--- a/src/main/java/de/extremeenvironment/messageservice/service/UserHolderService.java
+++ b/src/main/java/de/extremeenvironment/messageservice/service/UserHolderService.java
@@ -1,0 +1,27 @@
+package de.extremeenvironment.messageservice.service;
+
+import de.extremeenvironment.messageservice.domain.UserHolder;
+import de.extremeenvironment.messageservice.repository.UserHolderRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Created by on 29.06.16.
+ *
+ * @author David Steiman
+ */
+@Service
+public class UserHolderService {
+    private UserHolderRepository userHolderRepository;
+
+    @Autowired
+    public UserHolderService(UserHolderRepository userHolderRepository) {
+        this.userHolderRepository = userHolderRepository;
+    }
+
+    public UserHolder findOrCreateByUserId(Long id) {
+        return userHolderRepository
+            .findOneByUserId(id)
+            .orElse(userHolderRepository.save(new UserHolder(id)));
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
@@ -1,6 +1,8 @@
 package de.extremeenvironment.messageservice.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
+import de.extremeenvironment.messageservice.client.Account;
+import de.extremeenvironment.messageservice.client.UserClient;
 import de.extremeenvironment.messageservice.domain.Conversation;
 import de.extremeenvironment.messageservice.domain.Message;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
@@ -35,11 +37,17 @@ public class ConversationResource {
     private ConversationRepository conversationRepository;
 
     private MessageRepository messageRepository;
+    private UserClient userClient;
 
     @Inject
-    public ConversationResource(ConversationRepository conversationRepository, MessageRepository messageRepository) {
+    public ConversationResource(
+        ConversationRepository conversationRepository,
+        MessageRepository messageRepository,
+        UserClient userClient
+    ) {
         this.conversationRepository = conversationRepository;
         this.messageRepository = messageRepository;
+        this.userClient = userClient;
     }
 
     /**
@@ -99,7 +107,15 @@ public class ConversationResource {
     @Timed
     public List<Conversation> getAllConversations(Principal currentUser) {
         log.debug("REST request to get all Conversations");
-        List<Conversation> conversations = conversationRepository.findAll();
+        List<Conversation> conversations;
+
+
+        if (currentUser == null) {
+            conversations = conversationRepository.findAll();
+        } else {
+            Account userAccount = userClient.getAccount(currentUser.getName());
+            conversations = conversationRepository.readConversationsByUserId(userAccount.getId());
+        }
         return conversations;
     }
 

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
@@ -19,6 +19,7 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,7 +97,7 @@ public class ConversationResource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public List<Conversation> getAllConversations() {
+    public List<Conversation> getAllConversations(Principal currentUser) {
         log.debug("REST request to get all Conversations");
         List<Conversation> conversations = conversationRepository.findAll();
         return conversations;

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/ConversationResource.java
@@ -1,0 +1,131 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import com.codahale.metrics.annotation.Timed;
+import de.extremeenvironment.messageservice.domain.Conversation;
+import de.extremeenvironment.messageservice.repository.ConversationRepository;
+import de.extremeenvironment.messageservice.web.rest.util.HeaderUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * REST controller for managing Conversation.
+ */
+@RestController
+@RequestMapping("/api")
+public class ConversationResource {
+
+    private final Logger log = LoggerFactory.getLogger(ConversationResource.class);
+        
+    @Inject
+    private ConversationRepository conversationRepository;
+    
+    /**
+     * POST  /conversations : Create a new conversation.
+     *
+     * @param conversation the conversation to create
+     * @return the ResponseEntity with status 201 (Created) and with body the new conversation, or with status 400 (Bad Request) if the conversation has already an ID
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @RequestMapping(value = "/conversations",
+        method = RequestMethod.POST,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<Conversation> createConversation(@Valid @RequestBody Conversation conversation) throws URISyntaxException {
+        log.debug("REST request to save Conversation : {}", conversation);
+        if (conversation.getId() != null) {
+            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("conversation", "idexists", "A new conversation cannot already have an ID")).body(null);
+        }
+        Conversation result = conversationRepository.save(conversation);
+        return ResponseEntity.created(new URI("/api/conversations/" + result.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert("conversation", result.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * PUT  /conversations : Updates an existing conversation.
+     *
+     * @param conversation the conversation to update
+     * @return the ResponseEntity with status 200 (OK) and with body the updated conversation,
+     * or with status 400 (Bad Request) if the conversation is not valid,
+     * or with status 500 (Internal Server Error) if the conversation couldnt be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @RequestMapping(value = "/conversations",
+        method = RequestMethod.PUT,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<Conversation> updateConversation(@Valid @RequestBody Conversation conversation) throws URISyntaxException {
+        log.debug("REST request to update Conversation : {}", conversation);
+        if (conversation.getId() == null) {
+            return createConversation(conversation);
+        }
+        Conversation result = conversationRepository.save(conversation);
+        return ResponseEntity.ok()
+            .headers(HeaderUtil.createEntityUpdateAlert("conversation", conversation.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * GET  /conversations : get all the conversations.
+     *
+     * @return the ResponseEntity with status 200 (OK) and the list of conversations in body
+     */
+    @RequestMapping(value = "/conversations",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public List<Conversation> getAllConversations() {
+        log.debug("REST request to get all Conversations");
+        List<Conversation> conversations = conversationRepository.findAll();
+        return conversations;
+    }
+
+    /**
+     * GET  /conversations/:id : get the "id" conversation.
+     *
+     * @param id the id of the conversation to retrieve
+     * @return the ResponseEntity with status 200 (OK) and with body the conversation, or with status 404 (Not Found)
+     */
+    @RequestMapping(value = "/conversations/{id}",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<Conversation> getConversation(@PathVariable Long id) {
+        log.debug("REST request to get Conversation : {}", id);
+        Conversation conversation = conversationRepository.findOne(id);
+        return Optional.ofNullable(conversation)
+            .map(result -> new ResponseEntity<>(
+                result,
+                HttpStatus.OK))
+            .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    /**
+     * DELETE  /conversations/:id : delete the "id" conversation.
+     *
+     * @param id the id of the conversation to delete
+     * @return the ResponseEntity with status 200 (OK)
+     */
+    @RequestMapping(value = "/conversations/{id}",
+        method = RequestMethod.DELETE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<Void> deleteConversation(@PathVariable Long id) {
+        log.debug("REST request to delete Conversation : {}", id);
+        conversationRepository.delete(id);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert("conversation", id.toString())).build();
+    }
+
+}

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
@@ -8,6 +8,7 @@ import de.extremeenvironment.messageservice.domain.Message;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 import de.extremeenvironment.messageservice.repository.MessageRepository;
 import de.extremeenvironment.messageservice.service.UserHolderService;
+import de.extremeenvironment.messageservice.web.rest.dto.MessageDTO;
 import de.extremeenvironment.messageservice.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * REST controller for managing Message.
@@ -147,7 +149,7 @@ public class MessageResource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public List<Message> getAllMessages(@PathVariable("conversationId") Long conversationId) {
+    public List<MessageDTO> getAllMessages(@PathVariable("conversationId") Long conversationId) {
         log.debug("REST request to get all Messages");
 
         Conversation conversation = conversationRepository.findOne(conversationId);
@@ -155,7 +157,10 @@ public class MessageResource {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("message", "noconversation", "conversation not found")).body(new LinkedList<>());
         }*/
 
-        return messageRepository.findAllByConversationId(conversationId);
+        return messageRepository.findAllByConversationId(conversationId)
+            .stream()
+            .map(MessageDTO::new)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.inject.Inject;
@@ -49,7 +50,8 @@ public class MessageResource {
         ConversationRepository conversationRepository,
         UserClient userClient,
         UserHolderService userHolderService
-        ) {
+    ) {
+
         this.messageRepository = messageRepository;
         this.conversationRepository = conversationRepository;
         this.userClient = userClient;
@@ -67,6 +69,7 @@ public class MessageResource {
         method = RequestMethod.POST,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
+    @Transactional
     public ResponseEntity<Message> createMessage(
         @Valid @RequestBody Message message,
         @PathVariable("conversationId") Long conversationId,
@@ -91,8 +94,8 @@ public class MessageResource {
             }
         }
 
-        conversation.addMessage(message);
-        //conversationRepository.save(conversation);
+        //conversation.addMessage(message);
+        conversationRepository.save(conversation);
         Message result = messageRepository.save(message);
         return ResponseEntity.created(new URI("/api/messages/" + result.getId()))
             .headers(HeaderUtil.createEntityCreationAlert("message", result.getId().toString()))

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
@@ -12,12 +12,9 @@ import de.extremeenvironment.messageservice.web.rest.dto.MessageDTO;
 import de.extremeenvironment.messageservice.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,8 +23,6 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -96,7 +91,7 @@ public class MessageResource {
             Account userAccount = userClient.getAccount(currentUser.getName());
 
             if (userAccount != null) {
-                message.setUser(userHolderService.findOrCreateByUserId(userAccount.getId()));
+                message.setUser(userHolderService.findOrCreateByAccount(userAccount));
             }
         }
 

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/MessageResource.java
@@ -15,6 +15,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +25,7 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -84,9 +87,10 @@ public class MessageResource {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("message", "noconversation", "conversation not found")).body(null);
         }
 
-
         //fetch user
         if (currentUser != null) {
+            log.info("saving message for user {}", currentUser.getName());
+
             Account userAccount = userClient.getAccount(currentUser.getName());
 
             if (userAccount != null) {

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/UserHolderResource.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/UserHolderResource.java
@@ -1,0 +1,131 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import com.codahale.metrics.annotation.Timed;
+import de.extremeenvironment.messageservice.domain.UserHolder;
+import de.extremeenvironment.messageservice.repository.UserHolderRepository;
+import de.extremeenvironment.messageservice.web.rest.util.HeaderUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * REST controller for managing UserHolder.
+ */
+@RestController
+@RequestMapping("/api")
+public class UserHolderResource {
+
+    private final Logger log = LoggerFactory.getLogger(UserHolderResource.class);
+        
+    @Inject
+    private UserHolderRepository userHolderRepository;
+    
+    /**
+     * POST  /user-holders : Create a new userHolder.
+     *
+     * @param userHolder the userHolder to create
+     * @return the ResponseEntity with status 201 (Created) and with body the new userHolder, or with status 400 (Bad Request) if the userHolder has already an ID
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @RequestMapping(value = "/user-holders",
+        method = RequestMethod.POST,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<UserHolder> createUserHolder(@Valid @RequestBody UserHolder userHolder) throws URISyntaxException {
+        log.debug("REST request to save UserHolder : {}", userHolder);
+        if (userHolder.getId() != null) {
+            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("userHolder", "idexists", "A new userHolder cannot already have an ID")).body(null);
+        }
+        UserHolder result = userHolderRepository.save(userHolder);
+        return ResponseEntity.created(new URI("/api/user-holders/" + result.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert("userHolder", result.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * PUT  /user-holders : Updates an existing userHolder.
+     *
+     * @param userHolder the userHolder to update
+     * @return the ResponseEntity with status 200 (OK) and with body the updated userHolder,
+     * or with status 400 (Bad Request) if the userHolder is not valid,
+     * or with status 500 (Internal Server Error) if the userHolder couldnt be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @RequestMapping(value = "/user-holders",
+        method = RequestMethod.PUT,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<UserHolder> updateUserHolder(@Valid @RequestBody UserHolder userHolder) throws URISyntaxException {
+        log.debug("REST request to update UserHolder : {}", userHolder);
+        if (userHolder.getId() == null) {
+            return createUserHolder(userHolder);
+        }
+        UserHolder result = userHolderRepository.save(userHolder);
+        return ResponseEntity.ok()
+            .headers(HeaderUtil.createEntityUpdateAlert("userHolder", userHolder.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * GET  /user-holders : get all the userHolders.
+     *
+     * @return the ResponseEntity with status 200 (OK) and the list of userHolders in body
+     */
+    @RequestMapping(value = "/user-holders",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public List<UserHolder> getAllUserHolders() {
+        log.debug("REST request to get all UserHolders");
+        List<UserHolder> userHolders = userHolderRepository.findAllWithEagerRelationships();
+        return userHolders;
+    }
+
+    /**
+     * GET  /user-holders/:id : get the "id" userHolder.
+     *
+     * @param id the id of the userHolder to retrieve
+     * @return the ResponseEntity with status 200 (OK) and with body the userHolder, or with status 404 (Not Found)
+     */
+    @RequestMapping(value = "/user-holders/{id}",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<UserHolder> getUserHolder(@PathVariable Long id) {
+        log.debug("REST request to get UserHolder : {}", id);
+        UserHolder userHolder = userHolderRepository.findOneWithEagerRelationships(id);
+        return Optional.ofNullable(userHolder)
+            .map(result -> new ResponseEntity<>(
+                result,
+                HttpStatus.OK))
+            .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    /**
+     * DELETE  /user-holders/:id : delete the "id" userHolder.
+     *
+     * @param id the id of the userHolder to delete
+     * @return the ResponseEntity with status 200 (OK)
+     */
+    @RequestMapping(value = "/user-holders/{id}",
+        method = RequestMethod.DELETE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public ResponseEntity<Void> deleteUserHolder(@PathVariable Long id) {
+        log.debug("REST request to delete UserHolder : {}", id);
+        userHolderRepository.delete(id);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert("userHolder", id.toString())).build();
+    }
+
+}

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/dto/ConversationDto.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/dto/ConversationDto.java
@@ -1,0 +1,76 @@
+package de.extremeenvironment.messageservice.web.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import de.extremeenvironment.messageservice.domain.Conversation;
+import de.extremeenvironment.messageservice.domain.UserHolder;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by on 22.06.16.
+ *
+ * @author David Steiman
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConversationDto {
+    private Long id;
+    private boolean active = true;
+    private String title;
+    private Set<UserHolder> users = new HashSet<>();
+
+    public ConversationDto() {
+    }
+
+    public ConversationDto(Conversation conversation) {
+        id = conversation.getId();
+        active = conversation.isActive();
+        title = conversation.getTitle();
+        users = conversation.getUsers();
+    }
+
+
+
+    public Conversation toConversation() {
+        Conversation conversation = new Conversation();
+
+        conversation.setId(id);
+        conversation.setActive(active);
+        conversation.setTitle(title);
+        conversation.setUsers(users);
+
+        return conversation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Set<UserHolder> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<UserHolder> users) {
+        this.users = users;
+    }
+}

--- a/src/main/java/de/extremeenvironment/messageservice/web/rest/dto/MessageDTO.java
+++ b/src/main/java/de/extremeenvironment/messageservice/web/rest/dto/MessageDTO.java
@@ -1,0 +1,60 @@
+package de.extremeenvironment.messageservice.web.rest.dto;
+
+import de.extremeenvironment.messageservice.domain.Message;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Created by on 01.07.16.
+ *
+ * @author David Steiman
+ */
+public class MessageDTO {
+    private Long id;
+    private String messageText;
+    private String messageUser;
+    private ZonedDateTime messageDate;
+
+    public MessageDTO() {
+    }
+
+    public MessageDTO(Message message) {
+        this.id = message.getId();
+        this.messageText = message.getMessageText();
+        this.messageUser = message.getUser().getUsername();
+        this.messageDate = message.getCreatedDate();
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getMessageText() {
+        return messageText;
+    }
+
+    public void setMessageText(String messageText) {
+        this.messageText = messageText;
+    }
+
+    public String getMessageUser() {
+        return messageUser;
+    }
+
+    public void setMessageUser(String messageUser) {
+        this.messageUser = messageUser;
+    }
+
+    public ZonedDateTime getMessageDate() {
+        return messageDate;
+    }
+
+    public void setMessageDate(ZonedDateTime messageDate) {
+        this.messageDate = messageDate;
+    }
+}

--- a/src/main/resources/.h2.server.properties
+++ b/src/main/resources/.h2.server.properties
@@ -1,4 +1,5 @@
 #H2 Server Properties
+#Wed Jun 29 12:25:16 CEST 2016
 0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./target/h2db/db/messageservice|MessageService
 webAllowOthers=true
 webPort=8082

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -73,7 +73,8 @@ jhipster:
                 tokenValidityInSeconds: 86400
         clientAuthorization:
             # change this depending on your authorization server
-            tokenUrl: http://localhost:8080/uaa/oauth/token
+            tokenUrl: http://userservice:8080/oauth/token
+            tokenServiceId: userservice
             clientId: internal
             clientSecret: internal
     mail: # specific JHipster mail property, for standard properties see MailProperties

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -75,7 +75,8 @@ jhipster:
                 tokenValidityInSeconds: 86400
         clientAuthorization:
             # change this depending on your authorization server
-            tokenUrl: http://localhost:8080/uaa/oauth/token
+            tokenUrl: http://userservice:8080/oauth/token
+            tokenServiceId: userservice
             clientId: internal
             clientSecret: internal
     mail: # specific JHipster mail property, for standard properties see MailProperties

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -56,6 +56,13 @@ security:
 # ===================================================================
 
 jhipster:
+    security:
+        clientAuthorization:
+            # change this depending on your authorization server
+            tokenUrl: http://userservice:8080/oauth/token
+            tokenServiceId: userservice
+            clientId: internal
+            clientSecret: internal
     async:
         corePoolSize: 2
         maxPoolSize: 50

--- a/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_Message.xml
@@ -21,10 +21,14 @@
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="content" type="varchar(255)">
-                <constraints nullable="true" />
+            <column name="message_text" type="varchar(255)">
+                <constraints nullable="false" />
             </column>
             
+            <column name="conversation_id" type="bigint">
+                <constraints nullable="true" />
+            </column>
+
             <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
         </createTable>
         

--- a/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_Message.xml
@@ -25,6 +25,10 @@
                 <constraints nullable="false" />
             </column>
             
+            <column name="user_id" type="bigint">
+                <constraints nullable="true" />
+            </column>
+
             <column name="conversation_id" type="bigint">
                 <constraints nullable="true" />
             </column>

--- a/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <!--
+        Added the constraints for entity Message.
+    -->
+    <changeSet id="20160530071216-2" author="jhipster">
+        
+        <addForeignKeyConstraint baseColumnNames="conversation_id"
+                                 baseTableName="message"
+                                 constraintName="fk_message_conversation_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="conversation"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml
@@ -8,6 +8,12 @@
     -->
     <changeSet id="20160530071216-2" author="jhipster">
         
+        <addForeignKeyConstraint baseColumnNames="user_id"
+                                 baseTableName="message"
+                                 constraintName="fk_message_user_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_holder"/>
+
         <addForeignKeyConstraint baseColumnNames="conversation_id"
                                  baseTableName="message"
                                  constraintName="fk_message_conversation_id"

--- a/src/main/resources/config/liquibase/changelog/20160610141608_added_entity_Conversation.xml
+++ b/src/main/resources/config/liquibase/changelog/20160610141608_added_entity_Conversation.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <property name="now" value="now()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+    <property name="now" value="sysdate" dbms="oracle"/>
+
+    <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle"/>
+
+    <!--
+        Added the entity Conversation.
+    -->
+    <changeSet id="20160610141608-1" author="jhipster">
+        <createTable tableName="conversation">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="active" type="bit">
+                <constraints nullable="false" />
+            </column>
+            
+            <column name="title" type="varchar(255)">
+                <constraints nullable="true" />
+            </column>
+            
+            <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
+        </createTable>
+        
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_UserHolder.xml
+++ b/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_UserHolder.xml
@@ -25,10 +25,6 @@
                 <constraints nullable="false" />
             </column>
             
-            <column name="message_id" type="bigint">
-                <constraints nullable="true" />
-            </column>
-
             <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
         </createTable>
         

--- a/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_UserHolder.xml
+++ b/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_UserHolder.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <property name="now" value="now()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+    <property name="now" value="sysdate" dbms="oracle"/>
+
+    <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle"/>
+
+    <!--
+        Added the entity UserHolder.
+    -->
+    <changeSet id="20160610141609-1" author="jhipster">
+        <createTable tableName="user_holder">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="user_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            
+            <column name="message_id" type="bigint">
+                <constraints nullable="true" />
+            </column>
+
+            <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
+        </createTable>
+        
+        <createTable tableName="user_holder_conversation">
+            <column name="conversations_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_holders_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey columnNames="user_holders_id, conversations_id" tableName="user_holder_conversation"/>
+        
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml
+++ b/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml
@@ -8,12 +8,6 @@
     -->
     <changeSet id="20160610141609-2" author="jhipster">
         
-        <addForeignKeyConstraint baseColumnNames="message_id"
-                                 baseTableName="user_holder"
-                                 constraintName="fk_userholder_message_id"
-                                 referencedColumnNames="id"
-                                 referencedTableName="message"/>
-
         <addForeignKeyConstraint baseColumnNames="user_holders_id"
                                  baseTableName="user_holder_conversation"
                                  constraintName="fk_user_holder_conversation_conversation_id"

--- a/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml
+++ b/src/main/resources/config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <!--
+        Added the constraints for entity UserHolder.
+    -->
+    <changeSet id="20160610141609-2" author="jhipster">
+        
+        <addForeignKeyConstraint baseColumnNames="message_id"
+                                 baseTableName="user_holder"
+                                 constraintName="fk_userholder_message_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="message"/>
+
+        <addForeignKeyConstraint baseColumnNames="user_holders_id"
+                                 baseTableName="user_holder_conversation"
+                                 constraintName="fk_user_holder_conversation_conversation_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_holder"/>
+        <addForeignKeyConstraint baseColumnNames="conversations_id"
+                                 baseTableName="user_holder_conversation"
+                                 constraintName="fk_user_holder_conversation_userholder_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="conversation"/>
+        
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160701115600_changed_entity_UserHolder_and_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160701115600_changed_entity_UserHolder_and_Message.xml
@@ -14,7 +14,7 @@
     <property name="floatType" value="float" dbms="mysql, oracle"/>
 
     <changeSet id="20160701115600-1" author="jhipster">
-        <addColumn tableName="user_holder+">
+        <addColumn tableName="user_holder">
             <column name="username" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/config/liquibase/changelog/20160701115600_changed_entity_UserHolder_and_Message.xml
+++ b/src/main/resources/config/liquibase/changelog/20160701115600_changed_entity_UserHolder_and_Message.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <property name="now" value="now()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+    <property name="now" value="sysdate" dbms="oracle"/>
+
+    <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle"/>
+
+    <changeSet id="20160701115600-1" author="jhipster">
+        <addColumn tableName="user_holder+">
+            <column name="username" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="20160701115600-2" author="jhipster">
+        <addColumn tableName="message">
+            <column name="created_by" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_date" type="timestamp" defaultValueDate="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified_by" type="varchar(50)"/>
+            <column name="last_modified_date" type="timestamp"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -12,4 +12,5 @@
     <include file="classpath:config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
+    <include file="classpath:config/liquibase/changelog/20160701115600_changed_entity_UserHolder_and_Message.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -6,6 +6,10 @@
 
     <include file="classpath:config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160530071216_added_entity_Message.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20160610141608_added_entity_Conversation.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20160610141609_added_entity_UserHolder.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
+    <include file="classpath:config/liquibase/changelog/20160530071216_added_entity_constraints_Message.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20160610141609_added_entity_constraints_UserHolder.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>

--- a/src/test/java/de/extremeenvironment/messageservice/util/TestUtil.java
+++ b/src/test/java/de/extremeenvironment/messageservice/util/TestUtil.java
@@ -1,4 +1,4 @@
-package de.extremeenvironment.messageservice.web.rest;
+package de.extremeenvironment.messageservice.util;
 
 import de.extremeenvironment.messageservice.domain.util.JSR310DateTimeSerializer;
 import de.extremeenvironment.messageservice.domain.util.JSR310LocalDateDeserializer;

--- a/src/test/java/de/extremeenvironment/messageservice/util/WithMockOAuth2Authentication.java
+++ b/src/test/java/de/extremeenvironment/messageservice/util/WithMockOAuth2Authentication.java
@@ -1,0 +1,25 @@
+package de.extremeenvironment.messageservice.util;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by on 01.07.16.
+ *
+ * @author David Steiman
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockedOAuthUserSecurityContextFactory.class)
+public @interface WithMockOAuth2Authentication {
+    String username() default "TestUser";
+    String password() default "TestUser";
+
+    String clientId() default "testClient";
+    String[] scope() default {"default.read", "default.write"};
+
+    String[] roles() default {"USER", "ADMIN"};
+
+
+}

--- a/src/test/java/de/extremeenvironment/messageservice/util/WithMockedOAuthUserSecurityContextFactory.java
+++ b/src/test/java/de/extremeenvironment/messageservice/util/WithMockedOAuthUserSecurityContextFactory.java
@@ -1,0 +1,67 @@
+package de.extremeenvironment.messageservice.util;
+
+import org.mockito.internal.util.collections.Sets;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by on 01.07.16.
+ *
+ * @author David Steiman
+ */
+public class WithMockedOAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithMockOAuth2Authentication> {
+
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockOAuth2Authentication withClient) {
+        // Get the username
+        String username = withClient.username();
+        if (username == null) {
+            throw new IllegalArgumentException("Username cannot be null");
+        }
+
+        // Get the user roles
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (String role : withClient.roles()) {
+            if (role.startsWith("ROLE_")) {
+                throw new IllegalArgumentException("roles cannot start with ROLE_ Got " + role);
+            }
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+        }
+
+        // Get the client id
+        String clientId = withClient.clientId();
+        // get the oauth scopes
+        String[] scopes = withClient.scope();
+        Set<String> scopeCollection = Sets.newSet(scopes);
+
+        // Create the UsernamePasswordAuthenticationToken
+        User principal = new User(username, withClient.password(), true, true, true, true, authorities);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(),
+            principal.getAuthorities());
+
+
+        // Create the authorization request and OAuth2Authentication object
+        OAuth2Request authRequest = new OAuth2Request(null, clientId, null, true, scopeCollection, null, null, null,
+            null);
+        OAuth2Authentication oAuth = new OAuth2Authentication(authRequest, authentication);
+
+        // Add the OAuth2Authentication object to the security context
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(oAuth);
+
+        return context;
+    }
+}

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationResourceIntTest.java
@@ -1,0 +1,198 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import de.extremeenvironment.messageservice.MessageServiceApp;
+import de.extremeenvironment.messageservice.domain.Conversation;
+import de.extremeenvironment.messageservice.repository.ConversationRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.hamcrest.Matchers.hasItem;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+/**
+ * Test class for the ConversationResource REST controller.
+ *
+ * @see ConversationResource
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = MessageServiceApp.class)
+@WebAppConfiguration
+@IntegrationTest
+public class ConversationResourceIntTest {
+
+
+    private static final Boolean DEFAULT_ACTIVE = false;
+    private static final Boolean UPDATED_ACTIVE = true;
+    private static final String DEFAULT_TITLE = "AAAAA";
+    private static final String UPDATED_TITLE = "BBBBB";
+
+    @Inject
+    private ConversationRepository conversationRepository;
+
+    @Inject
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+    @Inject
+    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+
+    private MockMvc restConversationMockMvc;
+
+    private Conversation conversation;
+
+    @PostConstruct
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        ConversationResource conversationResource = new ConversationResource();
+        ReflectionTestUtils.setField(conversationResource, "conversationRepository", conversationRepository);
+        this.restConversationMockMvc = MockMvcBuilders.standaloneSetup(conversationResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setMessageConverters(jacksonMessageConverter).build();
+    }
+
+    @Before
+    public void initTest() {
+        conversation = new Conversation();
+        conversation.setActive(DEFAULT_ACTIVE);
+        conversation.setTitle(DEFAULT_TITLE);
+    }
+
+    @Test
+    @Transactional
+    public void createConversation() throws Exception {
+        int databaseSizeBeforeCreate = conversationRepository.findAll().size();
+
+        // Create the Conversation
+
+        restConversationMockMvc.perform(post("/api/conversations")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(conversation)))
+                .andExpect(status().isCreated());
+
+        // Validate the Conversation in the database
+        List<Conversation> conversations = conversationRepository.findAll();
+        assertThat(conversations).hasSize(databaseSizeBeforeCreate + 1);
+        Conversation testConversation = conversations.get(conversations.size() - 1);
+        assertThat(testConversation.isActive()).isEqualTo(DEFAULT_ACTIVE);
+        assertThat(testConversation.getTitle()).isEqualTo(DEFAULT_TITLE);
+    }
+
+    @Test
+    @Transactional
+    public void checkActiveIsRequired() throws Exception {
+        int databaseSizeBeforeTest = conversationRepository.findAll().size();
+        // set the field null
+        conversation.setActive(null);
+
+        // Create the Conversation, which fails.
+
+        restConversationMockMvc.perform(post("/api/conversations")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(conversation)))
+                .andExpect(status().isBadRequest());
+
+        List<Conversation> conversations = conversationRepository.findAll();
+        assertThat(conversations).hasSize(databaseSizeBeforeTest);
+    }
+
+    @Test
+    @Transactional
+    public void getAllConversations() throws Exception {
+        // Initialize the database
+        conversationRepository.saveAndFlush(conversation);
+
+        // Get all the conversations
+        restConversationMockMvc.perform(get("/api/conversations?sort=id,desc"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[*].id").value(hasItem(conversation.getId().intValue())))
+                .andExpect(jsonPath("$.[*].active").value(hasItem(DEFAULT_ACTIVE.booleanValue())))
+                .andExpect(jsonPath("$.[*].title").value(hasItem(DEFAULT_TITLE.toString())));
+    }
+
+    @Test
+    @Transactional
+    public void getConversation() throws Exception {
+        // Initialize the database
+        conversationRepository.saveAndFlush(conversation);
+
+        // Get the conversation
+        restConversationMockMvc.perform(get("/api/conversations/{id}", conversation.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(conversation.getId().intValue()))
+            .andExpect(jsonPath("$.active").value(DEFAULT_ACTIVE.booleanValue()))
+            .andExpect(jsonPath("$.title").value(DEFAULT_TITLE.toString()));
+    }
+
+    @Test
+    @Transactional
+    public void getNonExistingConversation() throws Exception {
+        // Get the conversation
+        restConversationMockMvc.perform(get("/api/conversations/{id}", Long.MAX_VALUE))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @Transactional
+    public void updateConversation() throws Exception {
+        // Initialize the database
+        conversationRepository.saveAndFlush(conversation);
+        int databaseSizeBeforeUpdate = conversationRepository.findAll().size();
+
+        // Update the conversation
+        Conversation updatedConversation = new Conversation();
+        updatedConversation.setId(conversation.getId());
+        updatedConversation.setActive(UPDATED_ACTIVE);
+        updatedConversation.setTitle(UPDATED_TITLE);
+
+        restConversationMockMvc.perform(put("/api/conversations")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(updatedConversation)))
+                .andExpect(status().isOk());
+
+        // Validate the Conversation in the database
+        List<Conversation> conversations = conversationRepository.findAll();
+        assertThat(conversations).hasSize(databaseSizeBeforeUpdate);
+        Conversation testConversation = conversations.get(conversations.size() - 1);
+        assertThat(testConversation.isActive()).isEqualTo(UPDATED_ACTIVE);
+        assertThat(testConversation.getTitle()).isEqualTo(UPDATED_TITLE);
+    }
+
+    @Test
+    @Transactional
+    public void deleteConversation() throws Exception {
+        // Initialize the database
+        conversationRepository.saveAndFlush(conversation);
+        int databaseSizeBeforeDelete = conversationRepository.findAll().size();
+
+        // Get the conversation
+        restConversationMockMvc.perform(delete("/api/conversations/{id}", conversation.getId())
+                .accept(TestUtil.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+
+        // Validate the database is empty
+        List<Conversation> conversations = conversationRepository.findAll();
+        assertThat(conversations).hasSize(databaseSizeBeforeDelete - 1);
+    }
+}

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationResourceIntTest.java
@@ -1,11 +1,13 @@
 package de.extremeenvironment.messageservice.web.rest;
 
 import de.extremeenvironment.messageservice.MessageServiceApp;
+import de.extremeenvironment.messageservice.client.UserClient;
 import de.extremeenvironment.messageservice.domain.Conversation;
 import de.extremeenvironment.messageservice.domain.Message;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 
 import de.extremeenvironment.messageservice.repository.MessageRepository;
+import de.extremeenvironment.messageservice.util.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +20,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +59,9 @@ public class ConversationResourceIntTest {
     @Inject
     private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
 
+    @Inject
+    private UserClient userClient;
+
     private MockMvc restConversationMockMvc;
 
     private Conversation conversation;
@@ -68,8 +72,13 @@ public class ConversationResourceIntTest {
     @PostConstruct
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        ConversationResource conversationResource = new ConversationResource(conversationRepository, messageRepository);
-        ReflectionTestUtils.setField(conversationResource, "conversationRepository", conversationRepository);
+
+        ConversationResource conversationResource = new ConversationResource(
+            conversationRepository,
+            messageRepository,
+            userClient
+        );
+
         this.restConversationMockMvc = MockMvcBuilders.standaloneSetup(conversationResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setMessageConverters(jacksonMessageConverter).build();

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationUnitTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/ConversationUnitTest.java
@@ -1,0 +1,78 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import de.extremeenvironment.messageservice.MessageServiceApp;
+import de.extremeenvironment.messageservice.domain.Conversation;
+import de.extremeenvironment.messageservice.domain.Message;
+import de.extremeenvironment.messageservice.repository.ConversationRepository;
+import de.extremeenvironment.messageservice.repository.MessageRepository;
+import de.extremeenvironment.messageservice.service.ConversationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+/**
+ * Test class for the ConversationResource REST controller.
+ *
+ * @see ConversationResource
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = MessageServiceApp.class)
+@WebAppConfiguration
+@IntegrationTest
+public class ConversationUnitTest {
+
+    @Inject
+    private MessageRepository messageRepository;
+
+    @Inject
+    private ConversationRepository conversationRepository;
+
+    @Inject
+    private ConversationService conversationService;
+
+    @Test
+    public void findByConversationIdWorks() throws Exception {
+        Conversation cOne = new Conversation();
+        Conversation cTwo = new Conversation();
+
+        Message mOne = new Message("test1");
+        Message mTwo = new Message("test2");
+
+
+        conversationService.addMessageToConversation(cOne,mOne);
+        conversationService.addMessageToConversation(cTwo,mTwo);
+
+        cOne = conversationRepository.save(cOne);
+        cTwo =conversationRepository.save(cTwo);
+
+        List<Message> listOne = messageRepository.findAllByConversationId(cOne.getId());
+        List<Message> listTwo = messageRepository.findAllByConversationId(cTwo.getId());
+
+        assertThat(listOne.contains(mOne));
+        assertThat(listTwo.contains(mTwo));
+
+
+    }
+}

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
@@ -1,33 +1,61 @@
 package de.extremeenvironment.messageservice.web.rest;
 
 import de.extremeenvironment.messageservice.MessageServiceApp;
+import de.extremeenvironment.messageservice.client.UserClient;
 import de.extremeenvironment.messageservice.domain.Conversation;
 import de.extremeenvironment.messageservice.domain.Message;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 import de.extremeenvironment.messageservice.repository.MessageRepository;
-
+import de.extremeenvironment.messageservice.service.UserHolderService;
+import jdk.nashorn.internal.objects.annotations.Getter;
+import jdk.nashorn.internal.objects.annotations.Setter;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.hamcrest.Matchers.hasItem;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.IntegrationTest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.test.OAuth2ContextSetup;
+import org.springframework.security.oauth2.client.test.RestTemplateHolder;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.context.WebApplicationContext;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import java.util.List;
+import java.io.Serializable;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -39,9 +67,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = MessageServiceApp.class)
-@WebAppConfiguration
-@IntegrationTest
-public class MessageResourceIntTest {
+@WebIntegrationTest({"server.port:0", "spring.profiles.active:test"})
+public class MessageResourceIntTest{
 
     private static final String DEFAULT_MESSAGE_TEXT = "AAAAA";
     private static final String UPDATED_MESSAGE_TEXT = "BBBBB";
@@ -61,20 +88,43 @@ public class MessageResourceIntTest {
     @Inject
     private ConversationRepository conversationRepository;
 
+    @Inject
+    private UserClient userClient;
+
+    @Inject
+    private UserHolderService userHolderService;
+
+    @Inject
+    private WebApplicationContext context;
+
     private MockMvc restMessageMockMvc;
 
     private Message message;
     private Conversation conversation;
 
+
     @PostConstruct
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        MessageResource messageResource = new MessageResource(messageRepository, conversationRepository);
+        MessageResource messageResource = new MessageResource(
+            messageRepository,
+            conversationRepository,
+            userClient,
+            userHolderService
+        );
 
-        this.restMessageMockMvc = MockMvcBuilders.standaloneSetup(messageResource)
+        this.restMessageMockMvc = MockMvcBuilders
+            .standaloneSetup(messageResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
-            .setMessageConverters(jacksonMessageConverter).build();
+            .setMessageConverters(jacksonMessageConverter)
+            .build();
+
+/*        this.restMessageMockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();*/
     }
+
 
     @Before
     public void initTest() {
@@ -89,7 +139,8 @@ public class MessageResourceIntTest {
     }
 
     @Test
-    @Transactional
+    //@Transactional
+    //@WithMockUser(username = "tester")
     public void createMessage() throws Exception {
         int databaseSizeBeforeCreate = messageRepository.findAll().size();
 
@@ -97,6 +148,8 @@ public class MessageResourceIntTest {
 
 
         restMessageMockMvc.perform(post("/api/conversations/{conversationId}/messages", conversation.getId())
+                .with(authentication(getOauthTestAuthentication()) )
+                .sessionAttr("scopedTarget.oauth2ClientContext", getOauth2ClientContext())
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(message)))
                 .andExpect(status().isCreated());
@@ -106,6 +159,50 @@ public class MessageResourceIntTest {
         assertThat(messages).hasSize(databaseSizeBeforeCreate + 1);
         Message testMessage = messages.get(messages.size() - 1);
         assertThat(testMessage.getMessageText()).isEqualTo(DEFAULT_MESSAGE_TEXT);
+    }
+
+    private Authentication getOauthTestAuthentication() {
+        return new OAuth2Authentication(getOauth2Request(), getAuthentication());
+    }
+
+    private Authentication getAuthentication() {
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("Everything");
+
+        User userPrincipal = new User("user", "", true, true, true, true, authorities);
+
+        HashMap<String, String> details = new HashMap<>();
+        details.put("user_name", "bwatkins");
+        details.put("email", "bwatkins@test.org");
+        details.put("name", "Brian Watkins");
+
+        TestingAuthenticationToken token = new TestingAuthenticationToken(userPrincipal, null, authorities);
+        token.setAuthenticated(true);
+        token.setDetails(details);
+
+        return token;
+    }
+
+    private OAuth2ClientContext getOauth2ClientContext () {
+        OAuth2ClientContext mockClient = mock(OAuth2ClientContext.class);
+        when(mockClient.getAccessToken()).thenReturn(new DefaultOAuth2AccessToken("my-fun-token"));
+
+        return mockClient;
+    }
+
+
+    private OAuth2Request getOauth2Request() {
+        String clientId = "oauth-client-id";
+        Map<String, String> requestParameters = Collections.emptyMap();
+        boolean approved = true;
+        String redirectUrl = "http://my-redirect-url.com";
+        Set<String> responseTypes = Collections.emptySet();
+        Set<String> scopes = Collections.emptySet();
+        Set<String> resourceIds = Collections.emptySet();
+        Map<String, Serializable> extensionProperties = Collections.emptyMap();
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("Everything");
+
+        return new OAuth2Request(requestParameters, clientId, authorities,
+            approved, scopes, resourceIds, redirectUrl, responseTypes, extensionProperties);
     }
 
     @Test
@@ -135,7 +232,9 @@ public class MessageResourceIntTest {
         messageRepository.saveAndFlush(message);
 
         // Get all the messages
-        restMessageMockMvc.perform(get("/api/conversations/{conversationId}/messages?sort=id,desc", conversation.getId()))
+        restMessageMockMvc.perform(get("/api/conversations/{conversationId}/messages?sort=id,desc", conversation.getId())
+                    .with(user("tester").roles("USER", "ADMIN"))
+                )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.[*].id").value(hasItem(message.getId().intValue())))
@@ -208,4 +307,5 @@ public class MessageResourceIntTest {
         List<Message> messages = messageRepository.findAll();
         assertThat(messages).hasSize(databaseSizeBeforeDelete - 1);
     }
+
 }

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
@@ -4,6 +4,7 @@ import de.extremeenvironment.messageservice.MessageServiceApp;
 import de.extremeenvironment.messageservice.client.UserClient;
 import de.extremeenvironment.messageservice.domain.Conversation;
 import de.extremeenvironment.messageservice.domain.Message;
+import de.extremeenvironment.messageservice.domain.UserHolder;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 import de.extremeenvironment.messageservice.repository.MessageRepository;
 import de.extremeenvironment.messageservice.service.UserHolderService;
@@ -117,6 +118,8 @@ public class MessageResourceIntTest{
         message = new Message();
         message.setMessageText(DEFAULT_MESSAGE_TEXT);
 
+        message.setUser(new UserHolder(12L, "TestUser"));
+
         conversationRepository.save(conversation);
 
     }
@@ -178,7 +181,9 @@ public class MessageResourceIntTest{
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.[*].id").value(hasItem(message.getId().intValue())))
-                .andExpect(jsonPath("$.[*].messageText").value(hasItem(DEFAULT_MESSAGE_TEXT.toString())));
+                .andExpect(jsonPath("$.[*].messageText").value(hasItem(DEFAULT_MESSAGE_TEXT.toString())))
+                .andExpect(jsonPath("$.[*].messageUser").exists())
+                .andExpect(jsonPath("$.[*].messageDate").exists());
     }
 
     @Test

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java
@@ -7,6 +7,7 @@ import de.extremeenvironment.messageservice.domain.Message;
 import de.extremeenvironment.messageservice.domain.UserHolder;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 import de.extremeenvironment.messageservice.repository.MessageRepository;
+import de.extremeenvironment.messageservice.repository.UserHolderRepository;
 import de.extremeenvironment.messageservice.service.UserHolderService;
 import de.extremeenvironment.messageservice.util.TestUtil;
 import de.extremeenvironment.messageservice.util.WithMockOAuth2Authentication;
@@ -75,12 +76,16 @@ public class MessageResourceIntTest{
     private UserHolderService userHolderService;
 
     @Inject
+    private UserHolderRepository userHolderRepository;
+
+    @Inject
     private WebApplicationContext context;
 
     private MockMvc restMessageMockMvc;
 
     private Message message;
     private Conversation conversation;
+
 
 
     @PostConstruct
@@ -118,14 +123,17 @@ public class MessageResourceIntTest{
         message = new Message();
         message.setMessageText(DEFAULT_MESSAGE_TEXT);
 
-        message.setUser(new UserHolder(12L, "TestUser"));
+        UserHolder user = new UserHolder(12L, "TestUser");
+        user = userHolderRepository.save(user);
+        message.setUser(user);
+        user.getMessages().add(message);
 
         conversationRepository.save(conversation);
 
     }
 
     @Test
-    //@Transactional
+    @Transactional
     @WithMockOAuth2Authentication
     public void createMessage() throws Exception {
         int databaseSizeBeforeCreate = messageRepository.findAll().size();

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/Swagger2MarkupIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/Swagger2MarkupIntTest.java
@@ -1,0 +1,53 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import de.extremeenvironment.messageservice.MessageServiceApp;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import springfox.documentation.staticdocs.SwaggerResultHandler;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = MessageServiceApp.class)
+@WebAppConfiguration
+@IntegrationTest
+@ActiveProfiles("dev")
+public class Swagger2MarkupIntTest {
+
+
+    @Inject
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() throws IOException {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+        .build();
+    }
+
+
+    @Test
+    public void convertSwaggerToAsciiDoc() throws Exception {
+        this.mockMvc.perform(get("/v2/api-docs")
+            .accept(MediaType.APPLICATION_JSON))
+            .andDo(SwaggerResultHandler.outputDirectory("build/swagger")
+            .build())
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
@@ -1,0 +1,190 @@
+package de.extremeenvironment.messageservice.web.rest;
+
+import de.extremeenvironment.messageservice.MessageServiceApp;
+import de.extremeenvironment.messageservice.domain.UserHolder;
+import de.extremeenvironment.messageservice.repository.UserHolderRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.hamcrest.Matchers.hasItem;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+/**
+ * Test class for the UserHolderResource REST controller.
+ *
+ * @see UserHolderResource
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = MessageServiceApp.class)
+@WebAppConfiguration
+@IntegrationTest
+public class UserHolderResourceIntTest {
+
+
+    private static final Long DEFAULT_USER_ID = 1L;
+    private static final Long UPDATED_USER_ID = 2L;
+
+    @Inject
+    private UserHolderRepository userHolderRepository;
+
+    @Inject
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+    @Inject
+    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+
+    private MockMvc restUserHolderMockMvc;
+
+    private UserHolder userHolder;
+
+    @PostConstruct
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        UserHolderResource userHolderResource = new UserHolderResource();
+        ReflectionTestUtils.setField(userHolderResource, "userHolderRepository", userHolderRepository);
+        this.restUserHolderMockMvc = MockMvcBuilders.standaloneSetup(userHolderResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setMessageConverters(jacksonMessageConverter).build();
+    }
+
+    @Before
+    public void initTest() {
+        userHolder = new UserHolder();
+        userHolder.setUserId(DEFAULT_USER_ID);
+    }
+
+    @Test
+    @Transactional
+    public void createUserHolder() throws Exception {
+        int databaseSizeBeforeCreate = userHolderRepository.findAll().size();
+
+        // Create the UserHolder
+
+        restUserHolderMockMvc.perform(post("/api/user-holders")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(userHolder)))
+                .andExpect(status().isCreated());
+
+        // Validate the UserHolder in the database
+        List<UserHolder> userHolders = userHolderRepository.findAll();
+        assertThat(userHolders).hasSize(databaseSizeBeforeCreate + 1);
+        UserHolder testUserHolder = userHolders.get(userHolders.size() - 1);
+        assertThat(testUserHolder.getUserId()).isEqualTo(DEFAULT_USER_ID);
+    }
+
+    @Test
+    @Transactional
+    public void checkUserIdIsRequired() throws Exception {
+        int databaseSizeBeforeTest = userHolderRepository.findAll().size();
+        // set the field null
+        userHolder.setUserId(null);
+
+        // Create the UserHolder, which fails.
+
+        restUserHolderMockMvc.perform(post("/api/user-holders")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(userHolder)))
+                .andExpect(status().isBadRequest());
+
+        List<UserHolder> userHolders = userHolderRepository.findAll();
+        assertThat(userHolders).hasSize(databaseSizeBeforeTest);
+    }
+
+    @Test
+    @Transactional
+    public void getAllUserHolders() throws Exception {
+        // Initialize the database
+        userHolderRepository.saveAndFlush(userHolder);
+
+        // Get all the userHolders
+        restUserHolderMockMvc.perform(get("/api/user-holders?sort=id,desc"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[*].id").value(hasItem(userHolder.getId().intValue())))
+                .andExpect(jsonPath("$.[*].userId").value(hasItem(DEFAULT_USER_ID.intValue())));
+    }
+
+    @Test
+    @Transactional
+    public void getUserHolder() throws Exception {
+        // Initialize the database
+        userHolderRepository.saveAndFlush(userHolder);
+
+        // Get the userHolder
+        restUserHolderMockMvc.perform(get("/api/user-holders/{id}", userHolder.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(userHolder.getId().intValue()))
+            .andExpect(jsonPath("$.userId").value(DEFAULT_USER_ID.intValue()));
+    }
+
+    @Test
+    @Transactional
+    public void getNonExistingUserHolder() throws Exception {
+        // Get the userHolder
+        restUserHolderMockMvc.perform(get("/api/user-holders/{id}", Long.MAX_VALUE))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @Transactional
+    public void updateUserHolder() throws Exception {
+        // Initialize the database
+        userHolderRepository.saveAndFlush(userHolder);
+        int databaseSizeBeforeUpdate = userHolderRepository.findAll().size();
+
+        // Update the userHolder
+        UserHolder updatedUserHolder = new UserHolder();
+        updatedUserHolder.setId(userHolder.getId());
+        updatedUserHolder.setUserId(UPDATED_USER_ID);
+
+        restUserHolderMockMvc.perform(put("/api/user-holders")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(updatedUserHolder)))
+                .andExpect(status().isOk());
+
+        // Validate the UserHolder in the database
+        List<UserHolder> userHolders = userHolderRepository.findAll();
+        assertThat(userHolders).hasSize(databaseSizeBeforeUpdate);
+        UserHolder testUserHolder = userHolders.get(userHolders.size() - 1);
+        assertThat(testUserHolder.getUserId()).isEqualTo(UPDATED_USER_ID);
+    }
+
+    @Test
+    @Transactional
+    public void deleteUserHolder() throws Exception {
+        // Initialize the database
+        userHolderRepository.saveAndFlush(userHolder);
+        int databaseSizeBeforeDelete = userHolderRepository.findAll().size();
+
+        // Get the userHolder
+        restUserHolderMockMvc.perform(delete("/api/user-holders/{id}", userHolder.getId())
+                .accept(TestUtil.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+
+        // Validate the database is empty
+        List<UserHolder> userHolders = userHolderRepository.findAll();
+        assertThat(userHolders).hasSize(databaseSizeBeforeDelete - 1);
+    }
+}

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
@@ -45,7 +45,9 @@ public class UserHolderResourceIntTest {
 
 
     private static final Long DEFAULT_USER_ID = 1L;
+    private static final String DEFAULT_USER_NAME= "Alpha";
     private static final Long UPDATED_USER_ID = 2L;
+    private static final String UPDATED_USER_NAME = "Beta";
 
     @Inject
     private UserHolderRepository userHolderRepository;
@@ -81,6 +83,7 @@ public class UserHolderResourceIntTest {
 
         userHolder = new UserHolder();
         userHolder.setUserId(DEFAULT_USER_ID);
+        userHolder.setUsername(DEFAULT_USER_NAME);
 
         conversation.addMember(userHolder);
     }
@@ -176,6 +179,7 @@ public class UserHolderResourceIntTest {
         UserHolder updatedUserHolder = new UserHolder();
         updatedUserHolder.setId(userHolder.getId());
         updatedUserHolder.setUserId(UPDATED_USER_ID);
+        updatedUserHolder.setUsername(UPDATED_USER_NAME);
 
         restUserHolderMockMvc.perform(put("/api/conversations/{conversationId}/members/", conversation.getId())
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -187,6 +191,7 @@ public class UserHolderResourceIntTest {
         assertThat(userHolders).hasSize(databaseSizeBeforeUpdate);
         UserHolder testUserHolder = userHolders.get(userHolders.size() - 1);
         assertThat(testUserHolder.getUserId()).isEqualTo(UPDATED_USER_ID);
+        assertThat(testUserHolder.getUsername()).isEqualTo(UPDATED_USER_NAME);
     }
 
     @Test

--- a/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
+++ b/src/test/java/de/extremeenvironment/messageservice/web/rest/UserHolderResourceIntTest.java
@@ -6,6 +6,7 @@ import de.extremeenvironment.messageservice.domain.UserHolder;
 import de.extremeenvironment.messageservice.repository.ConversationRepository;
 import de.extremeenvironment.messageservice.repository.UserHolderRepository;
 
+import de.extremeenvironment.messageservice.util.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +19,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -90,4 +90,4 @@ jhipster:
         contactEmail:
         license:
         licenseUrl:
-        enabled: false
+        enabled: true

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -74,7 +74,8 @@ jhipster:
                 tokenValidityInSeconds: 86400
         clientAuthorization:
             # change this depending on your authorization server
-            tokenUrl: http://localhost:8080/uaa/oauth/token
+            tokenUrl: http://uaa:9999/oauth/token
+            tokenServiceId: uaa
             clientId: internal
             clientSecret: internal
     metrics: # DropWizard Metrics configuration, used by MetricsConfiguration


### PR DESCRIPTION
dieser kleinere PR enthält:
- komplette Dokumentationsgenerierung via swagger2markup
- einbindung von [Netflix Feign](https://github.com/Netflix/feign) clients
- tests der feign clients mit Mock erweiterungen (erster Feldversuch der `@WithMockOAuth2Authentication` Annotation)
- erweiterung des Datenmodells und verifizierung
